### PR TITLE
Line Item Index Fix

### DIFF
--- a/cart-service/src/lib/dovetech-response-mapper.test.ts
+++ b/cart-service/src/lib/dovetech-response-mapper.test.ts
@@ -17,11 +17,7 @@ import {
 } from '../types/custom-commerce-tools.types';
 import { CartSetDirectDiscountsAction } from '@commercetools/platform-sdk';
 import crypto from 'crypto';
-import {
-  buildAmountOffBasketAction,
-  buildAmountOffLineItemAction,
-  buildAmountOffCostAction,
-} from '../test-helpers/dovetech-action-builders';
+import { buildAmountOffAction } from '../test-helpers/dovetech-action-builders';
 import * as cartWithSingleShippingModeDiscounted from '../test-helpers/cart-with-single-shipping-mode-discounted.json';
 import * as cartWithSingleShippingModeDirectDiscounts from '../test-helpers/cart-with-single-shipping-mode-direct-discounts.json';
 import { SHIPPING_COST_NAME } from './dovetech-property-constants';
@@ -57,8 +53,10 @@ it('should map DoveTech Amount off Basket apportioned line item amounts to line 
     .addLineItem(lineItem)
     .build();
 
-  const amountOffBasketAction: AmountOffAction =
-    buildAmountOffBasketAction(amountOff);
+  const amountOffBasketAction: AmountOffAction = buildAmountOffAction(
+    DoveTechActionType.AmountOffBasket,
+    amountOff
+  );
 
   const dtResponse = new DoveTechResponseBuilder()
     .addAction(amountOffBasketAction)
@@ -122,7 +120,10 @@ it('should map DoveTech Amount off Line Item discounts to line item direct disco
     .addLineItem(lineItem2)
     .build();
 
-  const amountOffLineItem: AmountOffAction = buildAmountOffLineItemAction(10);
+  const amountOffLineItem: AmountOffAction = buildAmountOffAction(
+    DoveTechActionType.AmountOffLineItem,
+    10
+  );
 
   const dtResponse = new DoveTechResponseBuilder()
     .addAction(amountOffLineItem)
@@ -197,8 +198,10 @@ it.each([
       .addLineItem(lineItem)
       .build();
 
-    const amountOffBasketAction: AmountOffAction =
-      buildAmountOffBasketAction(amountOff);
+    const amountOffBasketAction: AmountOffAction = buildAmountOffAction(
+      DoveTechActionType.AmountOffBasket,
+      amountOff
+    );
 
     const dtResponse = new DoveTechResponseBuilder()
       .addAction(amountOffBasketAction)
@@ -264,8 +267,10 @@ it('should return direct discounts correctly for multiple line items', () => {
     .addLineItem(lineItem2)
     .build();
 
-  const amountOffBasketAction: AmountOffAction =
-    buildAmountOffBasketAction(amountOff);
+  const amountOffBasketAction: AmountOffAction = buildAmountOffAction(
+    DoveTechActionType.AmountOffBasket,
+    amountOff
+  );
 
   const dtResponse = new DoveTechResponseBuilder()
     .addAction(amountOffBasketAction)
@@ -507,7 +512,8 @@ describe('shipping costs', () => {
 
     // original shipping amount is 10000
 
-    const amountOffCostAction: AmountOffAction = buildAmountOffCostAction(
+    const amountOffCostAction: AmountOffAction = buildAmountOffAction(
+      DoveTechActionType.AmountOffCost,
       amountOffInCurrencyUnits
     );
 

--- a/cart-service/src/lib/dovetech-response-mapper.ts
+++ b/cart-service/src/lib/dovetech-response-mapper.ts
@@ -142,16 +142,22 @@ const buildSetDirectDiscountForBasket = (
   const fractionDigits = commerceToolsCart.totalPrice.fractionDigits;
 
   const discountActions = dtBasketItems
-    .filter((item) => item.totalAmountOff > 0)
     .map((item, index) => {
+      // line items from Dovetech are returned in the same order as they are passed in
       const ctLineItem = commerceToolsCart.lineItems[index];
+
+      if (item.totalAmountOff === 0) {
+        return undefined;
+      }
+
       return buildSetDirectDiscountForLineItem(
         item,
         ctLineItem,
         currencyCode,
         fractionDigits
       );
-    });
+    })
+    .filter((item) => item !== undefined) as DirectDiscountDraft[];
 
   return discountActions;
 };

--- a/cart-service/src/test-helpers/cart-with-line-item-direct-discounts.json
+++ b/cart-service/src/test-helpers/cart-with-line-item-direct-discounts.json
@@ -1,308 +1,247 @@
 {
-  "anonymousId": "0223ad41-80b1-4317-8f01-862a1df769c9",
-  "cartState": "Active",
-  "country": "DE",
-  "createdAt": "2024-10-25T15:27:57.211Z",
-  "createdBy": {
-    "anonymousId": "0223ad41-80b1-4317-8f01-862a1df769c9",
-    "clientId": "hdnhVyq94LyqSm0wkLV8RF9e",
+  "type": "Cart",
+  "id": "3ad54eb1-1c1a-4c1c-9497-ec0915b1c027",
+  "version": 43,
+  "versionModifiedAt": "2024-11-26T15:57:17.794Z",
+  "lastMessageSequenceNumber": 1,
+  "createdAt": "2024-11-26T15:16:54.368Z",
+  "lastModifiedAt": "2024-11-26T15:57:17.794Z",
+  "lastModifiedBy": {
+    "clientId": "OROGSNAOBwHXXmqZVibihq_X",
     "isPlatformClient": false
   },
-  "customLineItems": [],
-  "deleteDaysAfterLastModification": 90,
-  "directDiscounts": [
-    {
-      "id": "aa623f1d-de83-4196-a939-e16d8b647707",
-      "references": [
-        { "id": "a5b1cc83-d74b-4d49-bdd9-30a13e328672", "typeId": "product" }
-      ],
-      "target": {
-        "predicate": "product.id = \"a5b1cc83-d74b-4d49-bdd9-30a13e328672\"",
-        "type": "lineItems"
-      },
-      "value": {
-        "money": [
-          {
-            "centAmount": 1000,
-            "currencyCode": "EUR",
-            "fractionDigits": 2,
-            "type": "centPrecision"
-          }
-        ],
-        "type": "absolute"
-      }
-    }
-  ],
-  "discountCodes": [],
-  "id": "82ca4bd5-4820-4770-a35c-93deb4d9b2f6",
-  "inventoryMode": "None",
-  "itemShippingAddresses": [],
-  "lastMessageSequenceNumber": 1,
-  "lastModifiedAt": "2024-10-25T15:29:43.722Z",
-  "lastModifiedBy": {
-    "anonymousId": "0223ad41-80b1-4317-8f01-862a1df769c9",
-    "clientId": "hdnhVyq94LyqSm0wkLV8RF9e",
+  "createdBy": {
+    "clientId": "OROGSNAOBwHXXmqZVibihq_X",
     "isPlatformClient": false
   },
   "lineItems": [
     {
-      "addedAt": "2024-10-25T15:27:57.443Z",
-      "discountedPrice": {
-        "includedDiscounts": [
-          {
-            "discount": {
-              "id": "aa623f1d-de83-4196-a939-e16d8b647707",
-              "typeId": "direct-discount"
-            },
-            "discountedAmount": {
-              "centAmount": 1000,
-              "currencyCode": "EUR",
-              "fractionDigits": 2,
-              "type": "centPrecision"
-            }
-          }
-        ],
-        "value": {
-          "centAmount": 4299,
-          "currencyCode": "EUR",
-          "fractionDigits": 2,
-          "type": "centPrecision"
-        }
-      },
-      "discountedPricePerQuantity": [
-        {
-          "discountedPrice": {
-            "includedDiscounts": [
-              {
-                "discount": {
-                  "id": "aa623f1d-de83-4196-a939-e16d8b647707",
-                  "typeId": "direct-discount"
-                },
-                "discountedAmount": {
-                  "centAmount": 1000,
-                  "currencyCode": "EUR",
-                  "fractionDigits": 2,
-                  "type": "centPrecision"
-                }
-              }
-            ],
-            "value": {
-              "centAmount": 4299,
-              "currencyCode": "EUR",
-              "fractionDigits": 2,
-              "type": "centPrecision"
-            }
-          },
-          "quantity": 1
-        }
-      ],
-      "id": "abd6db05-e8de-486e-98d2-d5aa1cf36b89",
-      "lastModifiedAt": "2024-10-25T15:29:48.861Z",
-      "lineItemMode": "Standard",
-      "name": {
-        "de-DE": "Moderne Landschaftsmalerei",
-        "en-GB": "Modern Landscape Painting",
-        "en-US": "Modern Landscape Painting"
-      },
-      "perMethodTaxRate": [],
-      "price": {
-        "country": "DE",
-        "id": "db423e81-8098-42c3-9602-79859609eca6",
-        "value": {
-          "centAmount": 5299,
-          "currencyCode": "EUR",
-          "fractionDigits": 2,
-          "type": "centPrecision"
-        }
-      },
-      "priceMode": "Platform",
+      "id": "102d8572-8f27-4be0-9d76-ebc0e244fc1e",
       "productId": "a5b1cc83-d74b-4d49-bdd9-30a13e328672",
       "productKey": "modern-landscape-painting",
-      "productSlug": {
-        "de-DE": "moderne-landschaftsmalerei",
-        "en-GB": "modern-landscape-painting",
-        "en-US": "modern-landscape-painting"
+      "name": {
+        "en-GB": "Modern Landscape Painting",
+        "de-DE": "Moderne Landschaftsmalerei",
+        "en-US": "Modern Landscape Painting"
       },
       "productType": {
-        "id": "e04b1724-013c-4d6c-8f53-7a8807fdbe3a",
         "typeId": "product-type",
+        "id": "e04b1724-013c-4d6c-8f53-7a8807fdbe3a",
         "version": 1
       },
-      "quantity": 1,
-      "state": [
-        {
-          "quantity": 1,
-          "state": {
-            "id": "fce0e3a1-1ac3-47e4-b936-89d1a53c9905",
-            "typeId": "state"
-          }
-        }
-      ],
-      "taxRate": {
-        "amount": 0.19,
-        "country": "DE",
-        "id": "y2uQlkPH",
-        "includedInPrice": true,
-        "key": "vat-standard-de",
-        "name": "Standard VAT for Germany",
-        "subRates": []
-      },
-      "taxedPrice": {
-        "taxPortions": [
-          {
-            "amount": {
-              "centAmount": 686,
-              "currencyCode": "EUR",
-              "fractionDigits": 2,
-              "type": "centPrecision"
-            },
-            "name": "Standard VAT for Germany",
-            "rate": 0.19
-          }
-        ],
-        "totalGross": {
-          "centAmount": 4299,
-          "currencyCode": "EUR",
-          "fractionDigits": 2,
-          "type": "centPrecision"
-        },
-        "totalNet": {
-          "centAmount": 3613,
-          "currencyCode": "EUR",
-          "fractionDigits": 2,
-          "type": "centPrecision"
-        },
-        "totalTax": {
-          "centAmount": 686,
-          "currencyCode": "EUR",
-          "fractionDigits": 2,
-          "type": "centPrecision"
-        }
-      },
-      "taxedPricePortions": [],
-      "totalPrice": {
-        "centAmount": 4299,
-        "currencyCode": "EUR",
-        "fractionDigits": 2,
-        "type": "centPrecision"
+      "productSlug": {
+        "en-GB": "modern-landscape-painting",
+        "de-DE": "moderne-landschaftsmalerei",
+        "en-US": "modern-landscape-painting"
       },
       "variant": {
-        "assets": [],
+        "id": 1,
+        "sku": "MLP-01",
+        "prices": [
+          {
+            "id": "db423e81-8098-42c3-9602-79859609eca6",
+            "value": {
+              "type": "centPrecision",
+              "currencyCode": "EUR",
+              "centAmount": 5299,
+              "fractionDigits": 2
+            },
+            "country": "DE"
+          },
+          {
+            "id": "7b789210-2082-4e7b-a168-1027dde0aef5",
+            "value": {
+              "type": "centPrecision",
+              "currencyCode": "GBP",
+              "centAmount": 5299,
+              "fractionDigits": 2
+            },
+            "country": "GB"
+          },
+          {
+            "id": "e90dd6a3-a67d-4792-aae8-34177a4c5c6e",
+            "value": {
+              "type": "centPrecision",
+              "currencyCode": "USD",
+              "centAmount": 5299,
+              "fractionDigits": 2
+            },
+            "country": "US"
+          }
+        ],
+        "images": [
+          {
+            "url": "https://storage.googleapis.com/merchant-center-europe/sample-data/b2c-lifestyle/Modern_Landscape_Painting-1.1.jpeg",
+            "dimensions": {
+              "w": 5313,
+              "h": 5355
+            }
+          }
+        ],
         "attributes": [
           {
             "name": "productspec",
             "value": {
-              "de-DE": "- Öl auf Leinwand\n- Rahmen nicht im Lieferumfang enthalten\n- 3 Fuß mal 4 Fuß",
               "en-GB": "- Oil on canvas\n- Frame not included\n- 3ft by 4ft",
+              "de-DE": "- Öl auf Leinwand\n- Rahmen nicht im Lieferumfang enthalten\n- 3 Fuß mal 4 Fuß",
               "en-US": "- Oil on canvas\n- Frame not included\n- 3ft by 4ft"
             }
           },
           {
             "name": "color",
             "value": {
-              "de-DE": "Himmel blau:#87CEEB",
+              "en-US": "Sky Blue:#87CEEB",
               "en-GB": "Sky Blue:#87CEEB",
-              "en-US": "Sky Blue:#87CEEB"
+              "de-DE": "Himmel blau:#87CEEB"
             }
           }
         ],
+        "assets": [],
         "availability": {
-          "availableQuantity": 84,
-          "id": "c055928f-e0a8-4686-9dc8-bb477d034b21",
-          "isOnStock": true,
-          "version": 1
+          "channels": {
+            "fe117088-d238-4db2-8c5b-6b5aa56d1c9d": {
+              "isOnStock": false,
+              "availableQuantity": 0,
+              "version": 5,
+              "id": "c055928f-e0a8-4686-9dc8-bb477d034b21"
+            }
+          }
+        }
+      },
+      "price": {
+        "id": "db423e81-8098-42c3-9602-79859609eca6",
+        "value": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 5299,
+          "fractionDigits": 2
         },
-        "id": 1,
-        "images": [
+        "country": "DE"
+      },
+      "quantity": 1,
+      "discountedPrice": {
+        "value": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 4299,
+          "fractionDigits": 2
+        },
+        "includedDiscounts": [
           {
-            "dimensions": { "h": 5355, "w": 5313 },
-            "url": "https://storage.googleapis.com/merchant-center-europe/sample-data/b2c-lifestyle/Modern_Landscape_Painting-1.1.jpeg"
-          }
-        ],
-        "prices": [
-          {
-            "country": "DE",
-            "id": "db423e81-8098-42c3-9602-79859609eca6",
-            "value": {
-              "centAmount": 5299,
+            "discount": {
+              "typeId": "direct-discount",
+              "id": "21cdb4c8-9ad6-4896-9f37-ead2df0a5d13"
+            },
+            "discountedAmount": {
+              "type": "centPrecision",
               "currencyCode": "EUR",
-              "fractionDigits": 2,
-              "type": "centPrecision"
-            }
-          },
-          {
-            "country": "GB",
-            "id": "7b789210-2082-4e7b-a168-1027dde0aef5",
-            "value": {
-              "centAmount": 5299,
-              "currencyCode": "GBP",
-              "fractionDigits": 2,
-              "type": "centPrecision"
-            }
-          },
-          {
-            "country": "US",
-            "id": "e90dd6a3-a67d-4792-aae8-34177a4c5c6e",
-            "value": {
-              "centAmount": 5299,
-              "currencyCode": "USD",
-              "fractionDigits": 2,
-              "type": "centPrecision"
+              "centAmount": 1000,
+              "fractionDigits": 2
             }
           }
-        ],
-        "sku": "MLP-01"
-      }
+        ]
+      },
+      "discountedPricePerQuantity": [
+        {
+          "quantity": 1,
+          "discountedPrice": {
+            "value": {
+              "type": "centPrecision",
+              "currencyCode": "EUR",
+              "centAmount": 4299,
+              "fractionDigits": 2
+            },
+            "includedDiscounts": [
+              {
+                "discount": {
+                  "typeId": "direct-discount",
+                  "id": "21cdb4c8-9ad6-4896-9f37-ead2df0a5d13"
+                },
+                "discountedAmount": {
+                  "type": "centPrecision",
+                  "currencyCode": "EUR",
+                  "centAmount": 1000,
+                  "fractionDigits": 2
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "perMethodTaxRate": [],
+      "addedAt": "2024-11-26T15:52:54.372Z",
+      "lastModifiedAt": "2024-11-26T15:57:17.505Z",
+      "state": [
+        {
+          "quantity": 1,
+          "state": {
+            "typeId": "state",
+            "id": "fce0e3a1-1ac3-47e4-b936-89d1a53c9905"
+          }
+        }
+      ],
+      "priceMode": "Platform",
+      "lineItemMode": "Standard",
+      "totalPrice": {
+        "type": "centPrecision",
+        "currencyCode": "EUR",
+        "centAmount": 4299,
+        "fractionDigits": 2
+      },
+      "taxedPricePortions": []
     }
   ],
-  "origin": "Customer",
-  "refusedGifts": [],
-  "shipping": [],
-  "shippingAddress": { "country": "DE" },
+  "cartState": "Active",
+  "totalPrice": {
+    "type": "centPrecision",
+    "currencyCode": "EUR",
+    "centAmount": 4299,
+    "fractionDigits": 2
+  },
+  "country": "DE",
   "shippingMode": "Single",
-  "taxCalculationMode": "LineItemLevel",
-  "taxMode": "Platform",
-  "taxRoundingMode": "HalfEven",
-  "taxedPrice": {
-    "taxPortions": [
-      {
-        "amount": {
-          "centAmount": 686,
-          "currencyCode": "EUR",
-          "fractionDigits": 2,
-          "type": "centPrecision"
-        },
-        "name": "Standard VAT for Germany",
-        "rate": 0.19
-      }
-    ],
-    "totalGross": {
-      "centAmount": 4299,
-      "currencyCode": "EUR",
-      "fractionDigits": 2,
-      "type": "centPrecision"
+  "shipping": [],
+  "customLineItems": [],
+  "discountCodes": [],
+  "directDiscounts": [
+    {
+      "id": "21cdb4c8-9ad6-4896-9f37-ead2df0a5d13",
+      "value": {
+        "type": "absolute",
+        "money": [
+          {
+            "type": "centPrecision",
+            "currencyCode": "EUR",
+            "centAmount": 1000,
+            "fractionDigits": 2
+          }
+        ]
+      },
+      "target": {
+        "type": "lineItems",
+        "predicate": "sku = \"MLP-01\""
+      },
+      "references": []
+    }
+  ],
+  "custom": {
+    "type": {
+      "typeId": "type",
+      "id": "51cc98cc-4b3f-4d8b-8320-ec53836c3f88"
     },
-    "totalNet": {
-      "centAmount": 3613,
-      "currencyCode": "EUR",
-      "fractionDigits": 2,
-      "type": "centPrecision"
-    },
-    "totalTax": {
-      "centAmount": 686,
-      "currencyCode": "EUR",
-      "fractionDigits": 2,
-      "type": "centPrecision"
+    "fields": {
+      "dovetech-discounts-couponCodes": "[]",
+      "dovetech-discounts-evaluationResponse": "{\"actions\":[{\"id\":\"0b47cdf2-e0a5-4a7f-8958-a00aad81897e\",\"discountId\":\"e919f82b-6f83-4151-a048-4a489721ba50\",\"type\":\"AmountOffLineItem\",\"qualifiedCouponCode\":null,\"amountOffType\":\"AmountOff\",\"value\":10,\"amountOff\":10,\"displayMessages\":[]}],\"basket\":{\"total\":42.99,\"totalAmountOff\":10,\"items\":[{\"total\":42.99,\"totalAmountOff\":10,\"actions\":[{\"id\":\"0b47cdf2-e0a5-4a7f-8958-a00aad81897e\",\"subItemId\":1,\"amountOff\":10}]}]},\"aggregates\":{\"total\":42.99,\"totalAmountOff\":10},\"costs\":[],\"commitId\":null,\"evaluationLog\":null}",
+      "dovetech-discounts-evaluationCurrency": "EUR"
     }
   },
-  "totalLineItemQuantity": 1,
-  "totalPrice": {
-    "centAmount": 4299,
-    "currencyCode": "EUR",
-    "fractionDigits": 2,
-    "type": "centPrecision"
-  },
-  "type": "Cart",
-  "version": 15,
-  "versionModifiedAt": "2024-10-25T15:29:43.722Z"
+  "inventoryMode": "None",
+  "taxMode": "Platform",
+  "taxRoundingMode": "HalfEven",
+  "taxCalculationMode": "LineItemLevel",
+  "deleteDaysAfterLastModification": 90,
+  "refusedGifts": [],
+  "origin": "Customer",
+  "itemShippingAddresses": [],
+  "totalLineItemQuantity": 1
 }

--- a/cart-service/src/test-helpers/dovetech-action-builders.ts
+++ b/cart-service/src/test-helpers/dovetech-action-builders.ts
@@ -18,6 +18,20 @@ export const buildAmountOffBasketAction = (
   };
 };
 
+export const buildAmountOffLineItemAction = (
+  amountOff: number,
+  value = amountOff
+): AmountOffAction => {
+  return {
+    id: crypto.randomUUID(),
+    amountOff: amountOff,
+    discountId: crypto.randomUUID(),
+    type: DoveTechActionType.AmountOffLineItem,
+    amountOffType: AmountOffType.AmountOff,
+    value,
+  };
+};
+
 export const buildAmountOffCostAction = (
   amountOff: number,
   value = amountOff

--- a/cart-service/src/test-helpers/dovetech-action-builders.ts
+++ b/cart-service/src/test-helpers/dovetech-action-builders.ts
@@ -4,7 +4,8 @@ import {
   DoveTechActionType,
 } from '../types/dovetech.types';
 
-export const buildAmountOffBasketAction = (
+export const buildAmountOffAction = (
+  type: DoveTechActionType,
   amountOff: number,
   value = amountOff
 ): AmountOffAction => {
@@ -12,35 +13,7 @@ export const buildAmountOffBasketAction = (
     id: crypto.randomUUID(),
     amountOff: amountOff,
     discountId: crypto.randomUUID(),
-    type: DoveTechActionType.AmountOffBasket,
-    amountOffType: AmountOffType.AmountOff,
-    value,
-  };
-};
-
-export const buildAmountOffLineItemAction = (
-  amountOff: number,
-  value = amountOff
-): AmountOffAction => {
-  return {
-    id: crypto.randomUUID(),
-    amountOff: amountOff,
-    discountId: crypto.randomUUID(),
-    type: DoveTechActionType.AmountOffLineItem,
-    amountOffType: AmountOffType.AmountOff,
-    value,
-  };
-};
-
-export const buildAmountOffCostAction = (
-  amountOff: number,
-  value = amountOff
-): AmountOffAction => {
-  return {
-    id: crypto.randomUUID(),
-    amountOff: amountOff,
-    discountId: crypto.randomUUID(),
-    type: DoveTechActionType.AmountOffCost,
+    type: type,
     amountOffType: AmountOffType.AmountOff,
     value,
   };

--- a/cart-service/src/tests/service-endpoint.tests.ts
+++ b/cart-service/src/tests/service-endpoint.tests.ts
@@ -17,10 +17,7 @@ import {
   CartActionType,
   CartOrOrder,
 } from '../types/custom-commerce-tools.types';
-import {
-  buildAmountOffBasketAction,
-  buildAmountOffCostAction,
-} from '../test-helpers/dovetech-action-builders';
+import { buildAmountOffAction } from '../test-helpers/dovetech-action-builders';
 import { SHIPPING_COST_NAME } from '../lib/dovetech-property-constants';
 import * as cartWithSingleShippingModeDiscounted from '../test-helpers/cart-with-single-shipping-mode-discounted.json';
 import * as orderWithEvaluationResult from '../test-helpers/order-with-evaluation-result.json';
@@ -64,8 +61,10 @@ test('should return set direct discount line item actions when Dovetech service 
     .addLineItem(lineItem)
     .build();
 
-  const amountOffBasketAction: AmountOffAction =
-    buildAmountOffBasketAction(amountOff);
+  const amountOffBasketAction: AmountOffAction = buildAmountOffAction(
+    DoveTechActionType.AmountOffBasket,
+    amountOff
+  );
 
   const dtResponse = new DoveTechResponseBuilder()
     .addAction(amountOffBasketAction)
@@ -123,9 +122,13 @@ test('should return set direct discounts when Dovetech service returns discounte
 
   const ctCart = cartWithSingleShippingModeDiscounted as CartOrOrder;
 
-  const amountOffBasketAction: AmountOffAction = buildAmountOffBasketAction(2);
+  const amountOffBasketAction: AmountOffAction = buildAmountOffAction(
+    DoveTechActionType.AmountOffBasket,
+    2
+  );
 
-  const amountOffCostAction: AmountOffAction = buildAmountOffCostAction(
+  const amountOffCostAction: AmountOffAction = buildAmountOffAction(
+    DoveTechActionType.AmountOffCost,
     amountOffShippingInCurrencyUnits
   );
 
@@ -248,22 +251,34 @@ test('should return 403 if no basic auth is provided', async () => {
 });
 
 test('should return 403 if incorrect basic auth is provided', async () => {
-  const response = await request(app).post('/cart-service').set('Authorization', 'Basic 123');
+  const response = await request(app)
+    .post('/cart-service')
+    .set('Authorization', 'Basic 123');
   expect(response.status).toBe(403);
   expect(response.body).toEqual({ message: 'Forbidden' });
 });
 
-test ('should return valid response if the correct basic auth is the current password', async () => {
+test('should return valid response if the correct basic auth is the current password', async () => {
   const basicAuthPassword = readConfiguration().basicAuthPwdCurrent;
-  const response = await request(app).post('/cart-service').set('Authorization', 'Basic ' + Buffer.from(basicAuthPassword).toString('base64'));
+  const response = await request(app)
+    .post('/cart-service')
+    .set(
+      'Authorization',
+      'Basic ' + Buffer.from(basicAuthPassword).toString('base64')
+    );
 
   //expecting 400 because the request body is empty
   expect(response.status).toBe(400);
 });
 
-test ('should return valid response if the correct basic auth is the previous password', async () => {
+test('should return valid response if the correct basic auth is the previous password', async () => {
   const basicAuthPassword = readConfiguration().basicAuthPwdPrevious;
-  const response = await request(app).post('/cart-service').set('Authorization', 'Basic ' + Buffer.from(basicAuthPassword).toString('base64'));
+  const response = await request(app)
+    .post('/cart-service')
+    .set(
+      'Authorization',
+      'Basic ' + Buffer.from(basicAuthPassword).toString('base64')
+    );
 
   //expecting 400 because the request body is empty
   expect(response.status).toBe(400);
@@ -281,7 +296,10 @@ test('should return 400 bad request when post invalid resource', async () => {
   const basicAuthPassword = readConfiguration().basicAuthPwdCurrent;
   const response = await request(app)
     .post('/cart-service')
-    .set('Authorization', 'Basic ' + Buffer.from(basicAuthPassword).toString('base64'))
+    .set(
+      'Authorization',
+      'Basic ' + Buffer.from(basicAuthPassword).toString('base64')
+    )
     .send({});
 
   expect(response.status).toBe(400);
@@ -330,8 +348,10 @@ test('should return no actions when type is Order', async () => {
 
   const ctCart = orderWithEvaluationResult as CartOrOrder;
 
-  const amountOffBasketAction: AmountOffAction =
-    buildAmountOffBasketAction(amountOff);
+  const amountOffBasketAction: AmountOffAction = buildAmountOffAction(
+    DoveTechActionType.AmountOffBasket,
+    amountOff
+  );
 
   const dtResponse = new DoveTechResponseBuilder()
     .addAction(amountOffBasketAction)
@@ -393,12 +413,14 @@ test('should reject order if aggregate-total-mismatch error returned', async () 
 });
 
 const postCart = async (cartOrOrder: CartOrOrder) => {
-
   const basicAuthPassword = readConfiguration().basicAuthPwdCurrent;
 
   return await request(app)
     .post('/cart-service')
-    .set('Authorization', 'Basic ' + Buffer.from(basicAuthPassword).toString('base64'))
+    .set(
+      'Authorization',
+      'Basic ' + Buffer.from(basicAuthPassword).toString('base64')
+    )
     .send({
       resource: {
         obj: cartOrOrder,


### PR DESCRIPTION
Fix an issue with the mapping of indexes from Dovetech to commerce tools. The processor API returns line items in the same order they are passed in. However, we were filtering out line items that didn't have a discount before using the index which resulted in an incorrect index if previous line items had no discount.

## Other Changes

* Added a test for this
* Refactored test action builders into one function