### PR TITLE
Logging - Remove `concurrencyLimit`

### DIFF
--- a/cart-service/src/connector/post-deploy.ts
+++ b/cart-service/src/connector/post-deploy.ts
@@ -9,8 +9,6 @@ import { getLogger } from '../utils/logger.utils';
 const CONNECT_APPLICATION_URL_KEY = 'CONNECT_SERVICE_URL';
 
 async function postDeploy(properties: Map<string, unknown>): Promise<void> {
-  // todo: remove this in time
-  getLogger(false).info('In postDeploy function');
   const applicationUrl = properties.get(CONNECT_APPLICATION_URL_KEY);
 
   assertString(applicationUrl, CONNECT_APPLICATION_URL_KEY);

--- a/cart-service/src/connector/pre-undeploy.ts
+++ b/cart-service/src/connector/pre-undeploy.ts
@@ -6,8 +6,6 @@ import { deleteCartUpdateExtension } from './actions';
 import { getLogger } from '../utils/logger.utils';
 
 async function preUndeploy(): Promise<void> {
-  // todo: remove this in time
-  getLogger(false).info('In preUndeploy function');
   const apiRoot = createApiRoot();
   await deleteCartUpdateExtension(apiRoot);
 }

--- a/cart-service/src/utils/logger.utils.ts
+++ b/cart-service/src/utils/logger.utils.ts
@@ -38,7 +38,6 @@ export const getLogger = (useBatchLogRecordProcessor: boolean = true) => {
         headers: {
           'api-key': configuration.otlpExporterEndpointApiKey,
         },
-        concurrencyLimit: 1,
       });
       loggerProvider.addLogRecordProcessor(
         useBatchLogRecordProcessor


### PR DESCRIPTION
Removing the `concurrencyLimit` seems to mean the logs on post deploy now work as expected. This seems to be a limit on pending requests to the logging: https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http/README.md?plain=1#L35

Also removed some test logs.