### PR TITLE
Ensure error thrown for bad requests

### DIFF
--- a/cart-service/src/lib/dovetech-discounts-service.ts
+++ b/cart-service/src/lib/dovetech-discounts-service.ts
@@ -48,6 +48,11 @@ export const evaluate = async (
     logger.error('Bad request returned from DoveTech discounts service', {
       meta: problemDetails,
     });
+
+    throw new CustomError(
+      response.status,
+      'Bad request returned from DoveTech discounts service'
+    );
   }
 
   return await response.json();

--- a/cart-service/src/tests/service-endpoint.tests.ts
+++ b/cart-service/src/tests/service-endpoint.tests.ts
@@ -371,7 +371,7 @@ test('should return empty actions when Dovetech service returns 500 and type is 
   });
 });
 
-test('should return error when Dovetech service returns 400 and type is order', async () => {
+test('should return 400 when Dovetech service returns 400 and type is order', async () => {
   const dtResponse = {
     type: 'https://httpstatuses.io/400',
     title: 'Bad Request',

--- a/cart-service/src/tests/service-endpoint.tests.ts
+++ b/cart-service/src/tests/service-endpoint.tests.ts
@@ -371,6 +371,27 @@ test('should return empty actions when Dovetech service returns 500 and type is 
   });
 });
 
+test('should return error when Dovetech service returns 400 and type is order', async () => {
+  const dtResponse = {
+    type: 'https://httpstatuses.io/400',
+    title: 'Bad Request',
+    status: 400,
+    detail:
+      "A currency code of 'Invalid' doesn't match any currencies in the project",
+  };
+
+  fetchMock.mockResponseOnce(JSON.stringify(dtResponse), { status: 400 });
+
+  const ctCart = new CommerceToolsCartBuilder('USD').setType('Order').build();
+
+  const response = await postCart(ctCart);
+
+  expect(response.status).toBe(400);
+  expect(response.body).toEqual({
+    message: 'Bad request returned from DoveTech discounts service',
+  });
+});
+
 test('should return error when Dovetech service returns 500 and type is order', async () => {
   fetchMock.mockResponse('', { status: 500 });
 


### PR DESCRIPTION
Fix issue introduced in https://github.com/dove-technology/commercetools-campaigns-connector/pull/21 where if there is a 400 Bad Request returned from the Dovetech service it is not handled correctly and a 500 status code will be returned to commercetools (for Orders, Carts always return 200).

The 400 error is now correctly returned to commercetools.