### PR TITLE
Update Error Responses

### DIFF
--- a/cart-service/src/app.ts
+++ b/cart-service/src/app.ts
@@ -80,7 +80,7 @@ app.post('/cart-service', async (req: Request, res: Response) => {
       logger.error('Failed to process order', error);
 
       if (error instanceof CustomError) {
-        setErrorResponse(res, error.statusCode as number, error.message);
+        setErrorResponse(res, error.statusCode, error.message);
       } else {
         setErrorResponse(res, 500, 'Internal Server Error');
       }

--- a/cart-service/src/app.ts
+++ b/cart-service/src/app.ts
@@ -80,7 +80,7 @@ app.post('/cart-service', async (req: Request, res: Response) => {
       logger.error('Failed to process order', error);
 
       if (error instanceof CustomError) {
-        setErrorResponse(res, error.statusCode, error.message);
+        setErrorResponse2(res, error);
       } else {
         setErrorResponse(res, 500, 'Internal Server Error');
       }
@@ -115,6 +115,13 @@ const setErrorResponse = (
 ) => {
   res.status(statusCode).json({
     message: message,
+  });
+};
+
+const setErrorResponse2 = (res: Response, customError: CustomError) => {
+  res.status(customError.statusCode).json({
+    message: customError.message,
+    errors: customError.errors,
   });
 };
 

--- a/cart-service/src/app.ts
+++ b/cart-service/src/app.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from 'express';
 import bodyParser from 'body-parser';
 import dotenv from 'dotenv';
-import CustomError from './errors/custom.error';
+import ServiceError from './errors/service.error';
 import { proxy } from './lib/commerce-tools-dovetech-proxy';
 import { readConfiguration } from './utils/config.utils';
 import { getLogger } from './utils/logger.utils';
@@ -84,8 +84,8 @@ app.post('/cart-service', async (req: Request, res: Response) => {
     if (resourceObject?.type === 'Order') {
       logger.error('Failed to process order', error);
 
-      if (error instanceof CustomError) {
-        setErrorCustomErrorResponse(res, error);
+      if (error instanceof ServiceError) {
+        setServiceErrorResponse(res, error);
       } else {
         setErrorResponse(res, 500, 'General', 'Internal Server Error');
       }
@@ -106,7 +106,7 @@ app.use('*wildcard', (_req: Request, res: Response) => {
 });
 
 const logError = (error: unknown, logger: winston.Logger) => {
-  if (error instanceof CustomError) {
+  if (error instanceof ServiceError) {
     logger.error(error.statusCode + ' ' + error.message, error);
   } else {
     logger.error('Unhandled Error:', error);
@@ -125,13 +125,10 @@ const setErrorResponse = (
   });
 };
 
-const setErrorCustomErrorResponse = (
-  res: Response,
-  customError: CustomError
-) => {
-  res.status(customError.statusCode).json({
-    message: customError.message,
-    errors: customError.errors,
+const setServiceErrorResponse = (res: Response, serviceError: ServiceError) => {
+  res.status(serviceError.statusCode).json({
+    message: serviceError.message,
+    errors: serviceError.errors,
   });
 };
 

--- a/cart-service/src/errors/custom.error.ts
+++ b/cart-service/src/errors/custom.error.ts
@@ -1,25 +1,19 @@
-type ErrorItem = {
-  statusCode: number | string;
+type CustomErrorItem = {
+  code: number | string;
   message: string;
-  referencedBy?: string;
 };
 
 class CustomError extends Error {
-  statusCode: number | string;
+  statusCode: number;
   message: string;
-  errors?: ErrorItem[];
+  errors?: CustomErrorItem[];
 
-  constructor(
-    statusCode: number | string,
-    message: string,
-    errors?: ErrorItem[]
-  ) {
+  constructor(statusCode: number, code: string, message: string) {
     super(message);
+
     this.statusCode = statusCode;
     this.message = message;
-    if (errors) {
-      this.errors = errors;
-    }
+    this.errors = [{ code, message }];
   }
 }
 

--- a/cart-service/src/errors/custom.error.ts
+++ b/cart-service/src/errors/custom.error.ts
@@ -1,12 +1,12 @@
 type CustomErrorItem = {
-  code: number | string;
+  code: string;
   message: string;
 };
 
 class CustomError extends Error {
   statusCode: number;
   message: string;
-  errors?: CustomErrorItem[];
+  errors: CustomErrorItem[];
 
   constructor(statusCode: number, code: string, message: string) {
     super(message);

--- a/cart-service/src/errors/environment-variables-validation.error.ts
+++ b/cart-service/src/errors/environment-variables-validation.error.ts
@@ -1,0 +1,25 @@
+type EnvironmentVariablesValidationErrorItem = {
+  code: number | string;
+  message: string;
+  referencedBy?: string;
+};
+
+class EnvironmentVariablesValidationError extends Error {
+  code: string;
+  message: string;
+  errors: EnvironmentVariablesValidationErrorItem[];
+
+  constructor(
+    code: string,
+    message: string,
+    errors: EnvironmentVariablesValidationErrorItem[]
+  ) {
+    super(message);
+
+    this.code = code;
+    this.message = message;
+    this.errors = errors;
+  }
+}
+
+export default EnvironmentVariablesValidationError;

--- a/cart-service/src/errors/service.error.ts
+++ b/cart-service/src/errors/service.error.ts
@@ -1,12 +1,12 @@
-type CustomErrorItem = {
+type ServiceErrorItem = {
   code: string;
   message: string;
 };
 
-class CustomError extends Error {
+class ServiceError extends Error {
   statusCode: number;
   message: string;
-  errors: CustomErrorItem[];
+  errors: ServiceErrorItem[];
 
   constructor(statusCode: number, code: string, message: string) {
     super(message);
@@ -17,4 +17,4 @@ class CustomError extends Error {
   }
 }
 
-export default CustomError;
+export default ServiceError;

--- a/cart-service/src/lib/commerce-tools-cart-mapper.test.ts
+++ b/cart-service/src/lib/commerce-tools-cart-mapper.test.ts
@@ -18,7 +18,7 @@ import * as cartWithSingleLineItem from '../test-helpers/cart-with-single-line-i
 import { getConfig } from '../test-helpers/test-config-helper';
 import { SHIPPING_COST_NAME } from './dovetech-property-constants';
 import { Configuration } from '../types/index.types';
-import CustomError from '../errors/custom.error';
+import ServiceError from '../errors/service.error';
 
 jest.mock('../utils/config.utils');
 
@@ -210,7 +210,7 @@ test('should throw error if evaluation result currency is different and type is 
     .setType('Order')
     .build();
 
-  expect(() => map(ctCart)).toThrow(CustomError);
+  expect(() => map(ctCart)).toThrow(ServiceError);
 });
 
 test('should map if evaluation result currency is different when type is Cart', async () => {

--- a/cart-service/src/lib/commerce-tools-cart-mapper.ts
+++ b/cart-service/src/lib/commerce-tools-cart-mapper.ts
@@ -32,7 +32,7 @@ import { CurrencyValue } from './currency-value';
 import { CurrencyValueType } from '../types/index.types';
 import type { Configuration } from '../types/index.types';
 import { merge } from 'object-mapper';
-import CustomError from '../errors/custom.error';
+import ServiceError from '../errors/service.error';
 
 export default (
   commerceToolsCart: CartOrOrder,
@@ -209,7 +209,7 @@ const verifyEvaluatedCartCurrencyMatchesOrderCurrency = (
   const currentCurrencyCode = getCartCurrencyCode(order);
 
   if (evaluationCurrency && evaluationCurrency !== currentCurrencyCode) {
-    throw new CustomError(
+    throw new ServiceError(
       400,
       'InvalidInput',
       `Currency code on the order (${currentCurrencyCode}) does not match the currency of the previous evaluation (${evaluationCurrency})`

--- a/cart-service/src/lib/commerce-tools-cart-mapper.ts
+++ b/cart-service/src/lib/commerce-tools-cart-mapper.ts
@@ -211,6 +211,7 @@ const verifyEvaluatedCartCurrencyMatchesOrderCurrency = (
   if (evaluationCurrency && evaluationCurrency !== currentCurrencyCode) {
     throw new CustomError(
       400,
+      'InvalidInput',
       `Currency code on the order (${currentCurrencyCode}) does not match the currency of the previous evaluation (${evaluationCurrency})`
     );
   }

--- a/cart-service/src/lib/dovetech-discounts-service.ts
+++ b/cart-service/src/lib/dovetech-discounts-service.ts
@@ -19,6 +19,7 @@ export const evaluate = async (
       if (!response.ok && response.status !== 400) {
         throw new CustomError(
           response.status,
+          'General',
           'Error while calling DoveTech discounts service.'
         );
       }
@@ -40,6 +41,7 @@ export const evaluate = async (
     ) {
       throw new CustomError(
         400,
+        'InvalidInput',
         'Expected aggregate total does not match latest aggregate total'
       );
     }
@@ -51,6 +53,7 @@ export const evaluate = async (
 
     throw new CustomError(
       response.status,
+      'InvalidInput',
       'Bad request returned from DoveTech discounts service'
     );
   }

--- a/cart-service/src/lib/dovetech-discounts-service.ts
+++ b/cart-service/src/lib/dovetech-discounts-service.ts
@@ -3,7 +3,7 @@ import {
   DoveTechDiscountsRequest,
   DoveTechDiscountsResponse,
 } from '../types/dovetech.types';
-import CustomError from '../errors/custom.error';
+import ServiceError from '../errors/service.error';
 import { getLogger } from '../utils/logger.utils';
 import { retryAsync } from 'ts-retry';
 
@@ -17,7 +17,7 @@ export const evaluate = async (
 
       // error we can retry
       if (!response.ok && response.status !== 400) {
-        throw new CustomError(
+        throw new ServiceError(
           response.status,
           'General',
           'Error while calling DoveTech discounts service.'
@@ -39,7 +39,7 @@ export const evaluate = async (
       problemDetails.type ===
       'https://dovetech.com/problem-responses/aggregate-total-mismatch'
     ) {
-      throw new CustomError(
+      throw new ServiceError(
         400,
         'InvalidInput',
         'Expected aggregate total does not match latest aggregate total'
@@ -51,7 +51,7 @@ export const evaluate = async (
       meta: problemDetails,
     });
 
-    throw new CustomError(
+    throw new ServiceError(
       response.status,
       'InvalidInput',
       'Bad request returned from DoveTech discounts service'

--- a/cart-service/src/tests/service-endpoint.tests.ts
+++ b/cart-service/src/tests/service-endpoint.tests.ts
@@ -389,6 +389,12 @@ test('should return 400 when Dovetech service returns 400 and type is order', as
   expect(response.status).toBe(400);
   expect(response.body).toEqual({
     message: 'Bad request returned from DoveTech discounts service',
+    errors: [
+      {
+        code: 'InvalidInput',
+        message: 'Bad request returned from DoveTech discounts service',
+      },
+    ],
   });
 });
 
@@ -402,6 +408,12 @@ test('should return error when Dovetech service returns 500 and type is order', 
   expect(response.status).toBe(500);
   expect(response.body).toEqual({
     message: 'Error while calling DoveTech discounts service.',
+    errors: [
+      {
+        code: 'General',
+        message: 'Error while calling DoveTech discounts service.',
+      },
+    ],
   });
 });
 
@@ -446,6 +458,13 @@ test('should reject order if aggregate-total-mismatch error returned', async () 
 
   expect(response.body).toEqual({
     message: 'Expected aggregate total does not match latest aggregate total',
+    errors: [
+      {
+        code: 'InvalidInput',
+        message:
+          'Expected aggregate total does not match latest aggregate total',
+      },
+    ],
   });
 });
 

--- a/cart-service/src/tests/service-endpoint.tests.ts
+++ b/cart-service/src/tests/service-endpoint.tests.ts
@@ -276,7 +276,15 @@ test('should return setCustomType action including commitId field if type is Ord
 test('should return 403 if no basic auth is provided', async () => {
   const response = await request(app).post('/cart-service');
   expect(response.status).toBe(403);
-  expect(response.body).toEqual({ message: 'Forbidden' });
+  expect(response.body).toEqual({
+    message: 'Forbidden',
+    errors: [
+      {
+        code: 'Forbidden',
+        message: 'Forbidden',
+      },
+    ],
+  });
 });
 
 test('should return 403 if incorrect basic auth is provided', async () => {
@@ -284,7 +292,15 @@ test('should return 403 if incorrect basic auth is provided', async () => {
     .post('/cart-service')
     .set('Authorization', 'Basic 123');
   expect(response.status).toBe(403);
-  expect(response.body).toEqual({ message: 'Forbidden' });
+  expect(response.body).toEqual({
+    message: 'Forbidden',
+    errors: [
+      {
+        code: 'Forbidden',
+        message: 'Forbidden',
+      },
+    ],
+  });
 });
 
 test('should return valid response if the correct basic auth is the current password', async () => {
@@ -318,6 +334,12 @@ test('should return 404 when non existing route', async () => {
   expect(response.status).toBe(404);
   expect(response.body).toEqual({
     message: 'Path not found.',
+    errors: [
+      {
+        code: 'ResourceNotFound',
+        message: 'Path not found.',
+      },
+    ],
   });
 });
 
@@ -334,6 +356,12 @@ test('should return 400 bad request when post invalid resource', async () => {
   expect(response.status).toBe(400);
   expect(response.body).toEqual({
     message: 'Bad request - Missing resource object.',
+    errors: [
+      {
+        code: 'InvalidInput',
+        message: 'Bad request - Missing resource object.',
+      },
+    ],
   });
 });
 

--- a/cart-service/src/utils/config.utils.ts
+++ b/cart-service/src/utils/config.utils.ts
@@ -1,4 +1,4 @@
-import CustomError from '../errors/custom.error';
+import EnvironmentVariablesValidationError from '../errors/environment-variables-validation.error';
 import type { Configuration } from '../types/index.types';
 import envValidators from '../validators/env.validators';
 import { getValidateMessages } from '../validators/helpers.validators';
@@ -28,7 +28,7 @@ export const readConfiguration = (): Configuration => {
   const validationErrors = getValidateMessages(envValidators, envVars);
 
   if (validationErrors.length) {
-    throw new CustomError(
+    throw new EnvironmentVariablesValidationError(
       'InvalidEnvironmentVariablesError',
       'Invalid Environment Variables please check your .env file',
       validationErrors


### PR DESCRIPTION
Ensure we return the errors array with any errors returned from the service

For 400 errors, if you don't return the `errors` array (with an object with `code` and `message` properties) the client receives a [`ExtensionBadResponse`](https://docs.commercetools.com/api/errors#extensionbadresponse) error with the message "The extension did not return the expected JSON.". Whereas if you include the `errors` array the client gets actual the error returned from the connector service.

For non 400 errors, the client always receives an `ExtensionBadResponse` error. We've made our error response consistent to the `errors` array is always included, but it doesn't appear to be necessary in this case.

## Other Changes

* Split out the environment variable error into a separate error as it doesn't have the same shape as the `CustomError`
* Renamed `CustomError` to `ServiceError` as this is the error returned from the service